### PR TITLE
link to the course in course signup partial

### DIFF
--- a/app/views/courses/_signup.html.haml
+++ b/app/views/courses/_signup.html.haml
@@ -3,9 +3,9 @@
   .list-group
     .list-group-item{ class: ['course', course.handle] }
       - if current_user.courses.include?(course)
-        %a.btn.btn-primary.btn-lg.register Enrolled
+        = link_to 'Enrolled', course, class: 'btn btn-primary btn-lg register'
       - else
-        = form_tag enroll_path(course), method: :post, class: 'register' do 
+        = form_tag enroll_path(course), method: :post, class: 'register' do
           %button.btn.btn-primary.btn-lg Enroll
 
       %h3= course.name
@@ -13,3 +13,4 @@
       %p.topics
         %strong Topics Covered:
         = categories.join(", ")
+      %p= link_to "View Course", course


### PR DESCRIPTION
- This partial is used for the course index and users find themselves on this page trying to navigate to the actual enrolled course but are unable to. the current work around is to click on the level up main logo to see all enrolled courses. I do not think this is intuitive
