### PR TITLE
Update broken blog link with archived copy

### DIFF
--- a/app/views/modules/_test_resources.html.haml
+++ b/app/views/modules/_test_resources.html.haml
@@ -2,7 +2,7 @@
   %h3 More Resources
 .panel-body
   %p.resource The creator of Rspec created a decent <a href='http://blog.davidchelimsky.net/blog/2007/05/14/an-introduction-to-rspec-part-i/'>beginning tutorial</a>, but if you need more coverage (ha!), grab a copy of the Rspec book from the library.
-  %p.resource Here's an interesting <a href='http://rubylearning.com/blog/2010/09/30/the-testing-mindset/'>blog post</a> on the mindset of doing TDD.
+  %p.resource Here's an interesting <a href='https://web.archive.org/web/20140707103657/http://rubylearning.com/blog/2010/09/30/the-testing-mindset/'>blog post</a> on the mindset of doing TDD.
   %p.resource A good place to start understanding BDD is <a href='https://blog.engineyard.com/2009/cucumber-introduction'>this article</a> on BDD via Cucumber by Engine Yard.
   %p.resource Once you've read that, RailsCasts did two good episodes [<a href='http://railscasts.com/episodes/155-beginning-with-cucumber'>1</a>, <a href='http://railscasts.com/episodes/159-more-on-cucumber'>2</a>] on Cucumber.
   %p.resource Writing good test code is just as hard and important as writing good app code. Here are <a href='http://www.thoughtworks.com/insights/blog/write-better-tests-5-steps'>a few good rules</a> for improving your test code.


### PR DESCRIPTION
The original link to the blog article is broken:
http://rubylearning.com/blog/2010/09/30/the-testing-mindset/

The wayback machine had a recent backup:
https://web.archive.org/web/20140707103657/http://rubylearning.com/blog/2010/09/30/the-testing-mindset/
