### PR TITLE
Course stallout email

### DIFF
--- a/app/interactors/remind_registration_dropoffs.rb
+++ b/app/interactors/remind_registration_dropoffs.rb
@@ -1,0 +1,20 @@
+class RemindRegistrationDropoffs
+  include Interactor
+
+  def call
+    lazy_users.each do |user|
+      user.update_attributes!(enrollment_reminder_sent: true)
+      remind(user)
+    end
+  end
+
+  private
+
+  def lazy_users
+    User.older.without_enrollments.without_enroll_email
+  end
+
+  def remind(user)
+    UserMailer.reg_reminder(user).deliver_now
+  end
+end

--- a/app/interactors/remind_registration_dropoffs.rb
+++ b/app/interactors/remind_registration_dropoffs.rb
@@ -2,7 +2,7 @@ class RemindRegistrationDropoffs
   include Interactor
 
   def call
-    lazy_users.each do |user|
+    context.users = lazy_users.each do |user|
       user.update_attributes!(enrollment_reminder_sent: true)
       remind(user)
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -7,4 +7,9 @@ class UserMailer < ActionMailer::Base
     @course = course
     mail(to: user.email, subject: "You've been enrolled!")
   end
+
+  def reg_reminder(user)
+    @user = user
+    mail(to: user.email, subject: "We miss you. Come on back.")
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,9 +16,14 @@ class User < ActiveRecord::Base
   validates_presence_of :name
   validates_uniqueness_of :email
 
+  scope :older, -> { where("users.created_at < ?", 2.weeks.ago) }
   scope :by_activity_date, -> { order("users.updated_at desc") }
+  scope :without_enroll_email, -> { where(enrollment_reminder_sent: false) }
   scope :with_completions, lambda {
     includes(:completions).where.not(completions: { id: nil })
+  }
+  scope :without_enrollments, lambda {
+    includes(:enrollments).where(enrollments: { id: nil })
   }
 
   def summary

--- a/app/views/user_mailer/reg_reminder.html.haml
+++ b/app/views/user_mailer/reg_reminder.html.haml
@@ -1,0 +1,6 @@
+%h3= "It's been really lonely without you."
+%p= "Hey there #{@user.name}. You signed up for LevelUpRails recently, but you haven't registered for any courses."
+%p= "We don't really have anything to offer as an incentive other than our undying respect, but please let us know if there's anything we can do help you get up and running."
+%p= link_to("Why not take a look at the courses?", courses_url)
+%br
+%p= "Have an awesome day. - The Management"

--- a/db/migrate/20150109225934_add_registration_reminder_flag_to_users.rb
+++ b/db/migrate/20150109225934_add_registration_reminder_flag_to_users.rb
@@ -1,0 +1,5 @@
+class AddRegistrationReminderFlagToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :enrollment_reminder_sent, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150108223205) do
+ActiveRecord::Schema.define(version: 20150109225934) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,22 +92,23 @@ ActiveRecord::Schema.define(version: 20150108223205) do
   add_index "skills", ["handle"], name: "index_skills_on_handle", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                              default: "", null: false
-    t.string   "encrypted_password",                 default: "", null: false
+    t.string   "email",                                default: "",    null: false
+    t.string   "encrypted_password",                   default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                      default: 0,  null: false
+    t.integer  "sign_in_count",                        default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "name",                   limit: 100,              null: false
+    t.string   "name",                     limit: 100,                 null: false
     t.string   "provider"
     t.string   "uid"
     t.string   "authentication_token"
+    t.boolean  "enrollment_reminder_sent",             default: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/lib/tasks/reminders.rake
+++ b/lib/tasks/reminders.rake
@@ -1,0 +1,6 @@
+desc "send reminder emails to unenrolled users"
+task :reg_reminder => :environment do
+  puts "Sending reminders to unenrolled users..."
+  int = RemindRegistrationDropoffs.call
+  puts "done. Sent #{int.users.length} emails."
+end

--- a/spec/interactors/remind_registration_dropoffs_spec.rb
+++ b/spec/interactors/remind_registration_dropoffs_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe RemindRegistrationDropoffs do
+  subject(:interactor) { RemindRegistrationDropoffs }
+  let(:mail) { double("UserMailer", deliver_now: true) }
+
+  let!(:user) { create(:user, name: "Old User", created_at: 3.weeks.ago) }
+  let!(:new_user) { create(:user, name: "New User") }
+  let(:enrollment) { create(:enrollment) }
+  let!(:enrolled_user) { enrollment.user.tap { |u| u.name = "Enrolled User" } }
+
+  it "sends email to users who haven't registered" do
+    expect_any_instance_of(subject).to receive(:lazy_users).and_return([user])
+    expect(UserMailer).to receive(:reg_reminder).with(user).and_return(mail)
+
+    subject.call
+  end
+
+  it "finds old users with no enrollments" do
+    expect_any_instance_of(subject).to receive(:remind).with(user)
+    expect_any_instance_of(subject).not_to receive(:remind).with(new_user)
+    expect_any_instance_of(subject).not_to receive(:remind).with(enrolled_user)
+
+    subject.call
+  end
+
+  it "sends emails only once" do
+    expect_any_instance_of(subject).to receive(:remind).with(user).once
+
+    subject.call
+    subject.call
+  end
+end


### PR DESCRIPTION
Fixes #49. Send an email when the user fails to enroll in a course after signup (and a couple weeks. we're lenient).

Needs cron scheduling. Just using the default heroku shit.