### PR TITLE
Fixes silent failure creating an account via github which has no name

### DIFF
--- a/app/models/concerns/omniauthable.rb
+++ b/app/models/concerns/omniauthable.rb
@@ -21,11 +21,16 @@ module Omniauthable
     def new_from_omniauth(auth)
       create(email: auth.info.email,
              password: Devise.friendly_token[0, 20],
-             name: auth.info.name,
+             name: name_from_auth(auth),
              provider: auth.provider,
              uid: auth.uid,
             )
     end
     private :new_from_omniauth
+
+    def name_from_auth(auth)
+      auth.info.name.presence || auth.info.email.split("@")[0]
+    end
+    private :name_from_auth
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -150,6 +150,20 @@ describe User do
         user = User.from_omniauth(auth)
         expect(user).to be_persisted
       end
+
+      context "when auth returns no name" do
+        let(:attrs) { { email: "tom@test.com", name: '' } }
+
+        it "saves the user params" do
+          user = User.from_omniauth(auth)
+          expect(user).to have_attributes(
+            email: attrs[:email],
+            name: attrs[:email].split("@")[0],
+            provider: "github",
+            uid: "1",
+          )
+        end
+      end
     end
 
     context "when the user registered before" do


### PR DESCRIPTION
* Issue would only occur if the github account has no name
* Uses the email prefix for the name when blank