### PR TITLE
add slack channel email

### DIFF
--- a/app/interactors/invite_to_slack.rb
+++ b/app/interactors/invite_to_slack.rb
@@ -1,0 +1,22 @@
+class InviteToSlack
+  include Interactor
+
+  def call
+    context.users.each { |user| invite_to_slack(user) }
+  end
+
+  private
+
+  def invite_to_slack(user)
+    update(user) && remind(user)
+  end
+
+  def update(user)
+    !user.slack_invite_sent_at &&
+      user.update_attributes!(slack_invite_sent_at: Time.now)
+  end
+
+  def remind(user)
+    UserMailer.slack_reminder(user).deliver_now
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -19,4 +19,9 @@ class UserMailer < ActionMailer::Base
     title = "LevelUp: Stuck working on #{@course.name}? Here comes help!"
     mail(to: @user.email, subject: title)
   end
+
+  def slack_reminder(user)
+    @user = user
+    mail(to: user.email, subject: "Get LevelUp help (and give it) on Slack.")
+  end
 end

--- a/app/views/user_mailer/slack_reminder.html.haml
+++ b/app/views/user_mailer/slack_reminder.html.haml
@@ -1,0 +1,9 @@
+%p= "Hey #{@user.name},"
+%p Programming is tough, and so is learning a new programming language. To fight through the hard parts, you need the support of other people on the same path.
+%p Originally, LevelUpRails was launched as a way to more efficiently onboard employees to one company. We've grown from that original goal, and now the vast majority of LevelUpRails users are independent learners. And while corporate users have lots of in-person support for their learning, we haven't had a good way to do that for independent folks until now.
+%p
+  Which is why we're excited to say that we're now available to help -- for free -- at
+  %a{href: "https://leveluprails.slack.com/"}https://leveluprails.slack.com/
+  \. Whether you're part of a company, learning a new stack, or trying to transition into a career in programming, we're here to help you. As you learn more, you can help others get the support they need to.
+%br
+%p= "I'll see you there. - Joe (jmmastey@gmail.com)"

--- a/db/migrate/20150518161610_add_slack_invite_sent_at_to_user.rb
+++ b/db/migrate/20150518161610_add_slack_invite_sent_at_to_user.rb
@@ -1,0 +1,5 @@
+class AddSlackInviteSentAtToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :slack_invite_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150119203208) do
+ActiveRecord::Schema.define(version: 20150518161610) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 20150119203208) do
     t.string   "authentication_token"
     t.boolean  "enrollment_reminder_sent",             default: false
     t.string   "organization",             limit: 50
+    t.datetime "slack_invite_sent_at"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/spec/interactors/invite_to_slack_spec.rb
+++ b/spec/interactors/invite_to_slack_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe InviteToSlack do
+  subject(:interactor) { described_class }
+  let(:mail) { double("UserMailer", deliver_now: true) }
+  let!(:user) { double("User", slack_invite_sent_at: nil) }
+
+  it "sends email as requested" do
+    user = double("User", slack_invite_sent_at: nil)
+    expect(UserMailer).to receive(:slack_reminder).with(user).and_return(mail)
+    expect_any_instance_of(subject).to receive(:update).and_return(true)
+
+    subject.call(users: [user])
+  end
+
+  it "updates the user" do
+    user = double("User", slack_invite_sent_at: nil)
+
+    expect(user).to receive(:update_attributes!)
+    subject.call(users: [user])
+  end
+
+  it "bails if the email has been sent before" do
+    user = double("User", slack_invite_sent_at: Date.today)
+
+    expect(UserMailer).not_to receive(:slack_reminder)
+    subject.call(users: [user])
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -2,16 +2,32 @@ require "spec_helper"
 
 describe UserMailer do
   let(:user) { build(:user) }
-  let(:course) { create(:course) }
-  let(:mail) { UserMailer.confirm_enrollment(user, course) }
 
-  it "confirms course enrollment" do
-    expect(mail.to).to include(user.email)
-    expect(mail.body).to include(course.name)
+  describe "#confirm_enrollment" do
+    let(:course) { create(:course) }
+    let(:mail) { UserMailer.confirm_enrollment(user, course) }
+
+    it "confirms course enrollment" do
+      expect(mail.to).to include(user.email)
+      expect(mail.body).to include(course.name)
+    end
+
+    it "actually sends the email" do
+      expect { mail.deliver_now! }.to change { deliveries }.by(1)
+    end
   end
 
-  it "actually sends the email" do
-    expect { mail.deliver_now! }.to change { deliveries }.by(1)
+  describe "#slack_reminder" do
+    let(:mail) { UserMailer.slack_reminder(user) }
+
+    it "includes the slack link" do
+      expect(mail.to).to include(user.email)
+      expect(mail.body).to include("https://leveluprails.slack.com/")
+    end
+
+    it "actually sends the email" do
+      expect { mail.deliver_now! }.to change { deliveries }.by(1)
+    end
   end
 
   def deliveries


### PR DESCRIPTION
Emailing users about the nascent https://leveluprails.slack.com, so there's a new mailer. Woot. Another flag or two and I'll need to migrate email flags to their own record.