### PR TITLE
Unsubscribe Interface Feature

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,6 +5,7 @@ class HomeController < ApplicationController
 
   include CategoryRouter
 
+  # GET /
   def index
     @courses = current_user.courses
   end

--- a/app/controllers/unsubscribe_controller.rb
+++ b/app/controllers/unsubscribe_controller.rb
@@ -1,0 +1,27 @@
+class UnsubscribeController < ApplicationController
+  before_filter :authenticate_user!, only: [:index]
+  before_filter :find_unsubscribe_by_token
+  before_filter :find_unsubscribe_by_user
+
+  def confirm
+    unless @link.present?
+      redirect_to :index
+      return
+    end
+
+    @link.user.update_attributes!(email_opt_out: "unsubscribed")
+  end
+
+  private
+
+  def find_unsubscribe_by_token
+    return unless params[:token].present?
+    @link = UnsubscribeLink.where(token: params[:token]).first
+  end
+
+  def find_unsubscribe_by_user
+    return if params[:token].present?
+    return unless current_user.present?
+    @link = UnsubscribeLink.for_user(current_user)
+  end
+end

--- a/app/models/unsubscribe_link.rb
+++ b/app/models/unsubscribe_link.rb
@@ -1,0 +1,9 @@
+class UnsubscribeLink < ActiveRecord::Base
+  belongs_to :user
+
+  def self.for_user(user)
+    where(user: user).first_or_create do |link|
+      link.token = SecureRandom.uuid
+    end
+  end
+end

--- a/app/views/unsubscribe/confirm.html.haml
+++ b/app/views/unsubscribe/confirm.html.haml
@@ -1,3 +1,5 @@
+%h2 Unsubscribe Happened, and There Was Great Wailing and Gnashing of Teeth
+
 .unsubscription_happened.sadface.cry-a-bit.dont-pity-me.look-just-go
   %p You have been unsubscribed from all LevelUpRails emails. We're sorry to see you go.
   %p If you try to retrieve your password, you'll still receive an email, because it wouldn't make sense not to.

--- a/app/views/unsubscribe/confirm.html.haml
+++ b/app/views/unsubscribe/confirm.html.haml
@@ -1,0 +1,5 @@
+.unsubscription_happened.sadface.cry-a-bit.dont-pity-me.look-just-go
+  %p You have been unsubscribed from all LevelUpRails emails. We're sorry to see you go.
+  %p If you try to retrieve your password, you'll still receive an email, because it wouldn't make sense not to.
+
+  %p Anyway, keep on rocking it, and have an awesome day!

--- a/app/views/unsubscribe/index.html.haml
+++ b/app/views/unsubscribe/index.html.haml
@@ -1,0 +1,7 @@
+%h2 Unsubscribe From Emails
+
+.unsubscription_confirmation
+  %p We try to send very few emails, mostly because they're boring to write. Are you sure you want to unsubscribe anyway?
+  %p If you no longer wish to receive emails from us, click this link:
+  %p
+    %a#unsubscribe{href: "/unsubscribe/#{@link.token}"} Unsubscribe from emails

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -8,6 +8,8 @@
   %h3= "#{@user.name}'s Profile"
   - if @user == current_user
     %span= link_to "Edit Profile", edit_user_registration_path, id: 'edit-profile'
+    |
+    %span= link_to "Unsubscribe from Emails", unsubscribe_path, id: 'unsubscribe'
 
   = render partial: 'enrolled_courses', locals: { user: @user }
   = render partial: 'recent_activity', locals: { user: @user }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,6 @@ Levelup::Application.routes.draw do
     delete "completion", to: "skills#uncomplete", as: :uncomplete
   end
 
-
   get "/unsubscribe", to: "unsubscribe#index", as: :unsubscribe
   get "/unsubscribe/:token", to: "unsubscribe#confirm"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,4 +16,8 @@ Levelup::Application.routes.draw do
     post "completion", to: "skills#complete", as: :complete
     delete "completion", to: "skills#uncomplete", as: :uncomplete
   end
+
+
+  get "/unsubscribe", to: "unsubscribe#index", as: :unsubscribe
+  get "/unsubscribe/:token", to: "unsubscribe#confirm"
 end

--- a/db/migrate/20150518215010_create_unsubscribe_links.rb
+++ b/db/migrate/20150518215010_create_unsubscribe_links.rb
@@ -1,0 +1,10 @@
+class CreateUnsubscribeLinks < ActiveRecord::Migration
+  def change
+    create_table :unsubscribe_links do |t|
+      t.references :user, null: false
+      t.string :token, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150518180143) do
+ActiveRecord::Schema.define(version: 20150518215010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,6 +93,13 @@ ActiveRecord::Schema.define(version: 20150518180143) do
   end
 
   add_index "skills", ["handle"], name: "index_skills_on_handle", using: :btree
+
+  create_table "unsubscribe_links", force: :cascade do |t|
+    t.integer  "user_id",    null: false
+    t.string   "token",      null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                                default: "",    null: false

--- a/features/step_definitions/profile_steps.rb
+++ b/features/step_definitions/profile_steps.rb
@@ -22,6 +22,10 @@ When /^I visit a user's profile page$/ do
   visit user_path(@user)
 end
 
+When /^I visit my profile$/ do
+  visit user_path(@user)
+end
+
 When /^I click a user's profile link$/ do
   click_link @user.name
 end

--- a/features/step_definitions/unsubscribe_steps.rb
+++ b/features/step_definitions/unsubscribe_steps.rb
@@ -1,0 +1,33 @@
+require 'pry'
+
+def unsub_link
+  @user ||= create_user
+  @link ||= UnsubscribeLink.for_user(@user)
+end
+
+When(/^I visit the unsubscribe page$/) do
+  binding.pry
+  visit unsubscribe_path
+end
+
+When(/^I click on unsubscribe$/) do
+  find("#unsubscribe").click
+end
+
+
+When(/^I visit unsubscribe with a token$/) do
+  visit "/unsubscribe/#{unsub_link.token}"
+end
+
+Then(/^I am on the unsubscribe confirmation page$/) do
+  expect(page.current_url).to match(/unsubscribe$/)
+  expect(page).to have_css(".unsubscription_confirmation")
+end
+
+Then(/^I see a message that I am unsubscribed$/) do
+  expect(page).to have_css(".unsubscription_happened")
+end
+
+Then(/^I am unsubscribed$/) do
+  expect(@user.reload.email_opt_out).to eq("unsubscribed")
+end

--- a/features/step_definitions/unsubscribe_steps.rb
+++ b/features/step_definitions/unsubscribe_steps.rb
@@ -27,3 +27,7 @@ end
 Then(/^I am unsubscribed$/) do
   expect(@user.reload.email_opt_out).to eq("unsubscribed")
 end
+
+Then(/^I see a link to unsubscribe from emails$/) do
+  expect(page).to have_css("#unsubscribe")
+end

--- a/features/step_definitions/unsubscribe_steps.rb
+++ b/features/step_definitions/unsubscribe_steps.rb
@@ -1,19 +1,15 @@
-require 'pry'
-
 def unsub_link
   @user ||= create_user
   @link ||= UnsubscribeLink.for_user(@user)
 end
 
 When(/^I visit the unsubscribe page$/) do
-  binding.pry
   visit unsubscribe_path
 end
 
 When(/^I click on unsubscribe$/) do
   find("#unsubscribe").click
 end
-
 
 When(/^I visit unsubscribe with a token$/) do
   visit "/unsubscribe/#{unsub_link.token}"

--- a/features/users/unsubscribe.feature
+++ b/features/users/unsubscribe.feature
@@ -1,0 +1,18 @@
+Feature: Unsubscribe from emails
+  As a registered user who's training
+  I want to unsubscribe from emails
+  Because I don't see value in them
+
+  Scenario: Unsubscribe while logged in
+    Given I am logged in
+    When I visit the unsubscribe page
+    Then I am on the unsubscribe confirmation page
+    When I click on unsubscribe
+    Then I am unsubscribed
+    And I see a message that I am unsubscribed
+
+  Scenario: Unsubscribe via an email
+    Given I am not logged in
+    When I visit unsubscribe with a token
+    Then I am unsubscribed
+    And I see a message that I am unsubscribed

--- a/features/users/unsubscribe.feature
+++ b/features/users/unsubscribe.feature
@@ -16,3 +16,8 @@ Feature: Unsubscribe from emails
     When I visit unsubscribe with a token
     Then I am unsubscribed
     And I see a message that I am unsubscribed
+
+  Scenario: Unsubscribe via profile
+    Given I am logged in
+    When I visit my profile
+    Then I see a link to unsubscribe from emails

--- a/spec/factories/unsubscribe_links.rb
+++ b/spec/factories/unsubscribe_links.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :unsubscribe_link do
-    token { SecureRandom::uuid }
+    token { SecureRandom.uuid }
 
     association :user
   end

--- a/spec/factories/unsubscribe_links.rb
+++ b/spec/factories/unsubscribe_links.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :unsubscribe_link do
+    token { SecureRandom::uuid }
+
+    association :user
+  end
+end

--- a/spec/models/unsubscribe_link_spec.rb
+++ b/spec/models/unsubscribe_link_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'pry'
+
+describe UnsubscribeLink do
+  context "#for_user" do
+    let(:user) { create(:user) }
+
+    it "returns the current instance for a user when available" do
+      UnsubscribeLink.create(user: user, token: "jimi-hendrix")
+      expect(UnsubscribeLink.for_user(user).token).to eq("jimi-hendrix")
+    end
+
+    it "creates an instance if there isn't one available" do
+      expect(UnsubscribeLink.for_user(user)).to be_an(UnsubscribeLink)
+    end
+  end
+
+end

--- a/spec/models/unsubscribe_link_spec.rb
+++ b/spec/models/unsubscribe_link_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'pry'
 
 describe UnsubscribeLink do
   context "#for_user" do
@@ -14,5 +13,4 @@ describe UnsubscribeLink do
       expect(UnsubscribeLink.for_user(user)).to be_an(UnsubscribeLink)
     end
   end
-
 end


### PR DESCRIPTION
In #88 we created an opt-out flag to prevent users from receiving more mail. This one adds an unsubscribe page to the user interface.

Need to add unsubscribe links to the emails that actually get sent, too.