### PR TITLE
Add completion burndown to user profiles

### DIFF
--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -24,3 +24,8 @@
     }
   }
 }
+
+.progress_chart .panel-body {
+  padding-top:0px;
+  margin-top:-20px;
+}

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -12,4 +12,8 @@ module UsersHelper
                        gravatar: { size: size, secure: request.ssl?,
                                    default: :identicon })
   end
+
+  def progress_summary_for(user)
+    ProgressSummary.new(user.enrollments.limit(1)).to_a
+  end
 end

--- a/app/models/progress_summary.rb
+++ b/app/models/progress_summary.rb
@@ -23,7 +23,7 @@ class ProgressSummary
     return val if val.kind_of? Date
     return val.to_date if val.respond_to? :to_date
     return Date.parse(val) if val.kind_of? String
-    raise InvalidArgumentError
+    raise ArgumentError
   end
   private :as_date
 

--- a/app/models/progress_summary.rb
+++ b/app/models/progress_summary.rb
@@ -4,8 +4,8 @@ class ProgressSummary
 
   def initialize(enrollments, options = {})
     @enrollments  = enrollments
-    @end_date     = options.fetch(:end_date, Date.today)
-    @start_date   = options.fetch(:start_date, enrollments.minimum(:created_at))
+    @end_date     = as_date(options.fetch(:end_date, Date.today))
+    @start_date   = as_date(options.fetch(:start_date, enrollments.minimum(:created_at)))
   end
 
   def to_a
@@ -15,9 +15,25 @@ class ProgressSummary
   end
 
   def summarize_progress_for_enrollment(enrollment)
-    { course_name: "sucka!", progress: {} }
+    { course_name: enrollment.course.name, progress: progress_burndown(enrollment) }
   end
   private :summarize_progress_for_enrollment
+
+  def as_date(val)
+    return val if val.kind_of? Date
+    return val.to_date if val.respond_to? :to_date
+    return Date.parse(val) if val.kind_of? String
+    raise InvalidArgumentError
+  end
+  private :as_date
+
+  def progress_burndown(enrollment)
+    skills_left = enrollment.course.skills.count
+    start_date.upto(end_date).each_with_object({}) do |date, hash|
+      hash[date] = skills_left
+    end
+  end
+  private :progress_burndown
 
   #
   # [

--- a/app/models/progress_summary.rb
+++ b/app/models/progress_summary.rb
@@ -29,11 +29,20 @@ class ProgressSummary
 
   def progress_burndown(enrollment)
     skills_left = enrollment.course.skills.count
+    completions = completions(enrollment)
+
     start_date.upto(end_date).each_with_object({}) do |date, hash|
+      skills_left -= completions[date].length if completions[date]
       hash[date] = skills_left
     end
   end
   private :progress_burndown
+
+  def completions(enrollment)
+    Completion.for_course(enrollment.user, enrollment.course)
+      .pluck(:created_at, :id)
+      .group_by { |c| as_date(c.first) }
+  end
 
   #
   # [

--- a/app/models/progress_summary.rb
+++ b/app/models/progress_summary.rb
@@ -1,0 +1,35 @@
+class ProgressSummary
+
+  attr_reader :enrollments, :end_date, :start_date
+
+  def initialize(enrollments, options = {})
+    @enrollments  = enrollments
+    @end_date     = options.fetch(:end_date, Date.today)
+    @start_date   = options.fetch(:start_date, enrollments.minimum(:created_at))
+  end
+
+  def to_a
+    @enrollments.map do |enrollment|
+      summarize_progress_for_enrollment(enrollment)
+    end
+  end
+
+  def summarize_progress_for_enrollment(enrollment)
+    { course_name: "sucka!", progress: {} }
+  end
+  private :summarize_progress_for_enrollment
+
+  #
+  # [
+  #   {
+  #     course_name: '',
+  #     progress: {
+  #       '2015-01-01' : 50,
+  #       '2015-01-02' : 48,
+  #     }
+  #   },
+  #   ...
+  # ]
+  #
+
+end

--- a/app/views/users/_progress.html.haml
+++ b/app/views/users/_progress.html.haml
@@ -4,3 +4,10 @@
       .panel-heading
         %h4 Skill Progress
       .panel-body= render partial: 'progress_bars'
+
+- if (@user == current_user || current_user.admin?) && @user.enrollments.any?
+  .progress_chart
+    .panel
+      .panel-heading
+        %h4 Burndown
+      .panel-body= render partial: 'progress_chart'

--- a/app/views/users/_progress_chart.html.haml
+++ b/app/views/users/_progress_chart.html.haml
@@ -1,0 +1,27 @@
+- summary = progress_summary_for(@user).first
+<script type="text/javascript" src="https://www.google.com/jsapi"></script>
+%script
+  = "chartData = function() { return ["
+  = "  ['Date', '#{summary[:course_name]}'],"
+  - summary[:progress].each do |date, remaining|
+    = "['#{date}', #{remaining}],"
+  = "] };"
+  = "console.log('loaded data')"
+
+
+:javascript
+  google.load('visualization', '1', { packages:['corechart'] });
+  google.setOnLoadCallback(drawChart);
+  function drawChart() {
+    var data = google.visualization.arrayToDataTable(chartData());
+
+    var options = {
+      hAxis: {title: 'Skills Remaining',  titleTextStyle: {color: '#333'}},
+      vAxis: {minValue: 0}
+    };
+
+    var chart = new google.visualization.AreaChart(document.getElementById('progress_burndown'));
+    chart.draw(data, options);
+  }
+
+<div id="progress_burndown" style="width: 100%; height: 300px;"></div>

--- a/spec/factories/enrollments.rb
+++ b/spec/factories/enrollments.rb
@@ -4,5 +4,7 @@ FactoryGirl.define do
   factory :enrollment do
     association :user
     association :course
+
+    created_at { Date.today - rand(1..20) }
   end
 end

--- a/spec/models/enrollment_spec.rb
+++ b/spec/models/enrollment_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Enrollment do
   describe "feed_for" do
     let(:user) { create(:user) }
-    let!(:enrollment) { create(:enrollment, user: user) }
+    let!(:enrollment) { create(:enrollment, user: user, created_at: 1.day.ago) }
 
     it "returns the recently completed enrollment" do
       expect(Enrollment.feed_for(user)).to include(enrollment)

--- a/spec/models/progress_summary_spec.rb
+++ b/spec/models/progress_summary_spec.rb
@@ -89,7 +89,7 @@ describe ProgressSummary do
       end
 
       it "reduces the remaining count when a skill is completed" do
-        completion = create(:completion, created_at: start_date + 1
+        completion = create(:completion, created_at: start_date + 1,
                             skill: course.skills.last, user: enrollment.user)
 
         expect(enrollment_data[:progress][start_date]).to eq(total_skills)

--- a/spec/models/progress_summary_spec.rb
+++ b/spec/models/progress_summary_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe ProgressSummary do
+
+  before do
+    FactoryGirl.create(:enrollment, created_at: oldest_date)
+    FactoryGirl.create(:enrollment, created_at: oldest_date+1)
+  end
+
+  let(:enrollments)     { Enrollment.all }
+  let(:num_enrollments) { enrollments.count }
+  let(:oldest_date)     { 1.year.ago }
+
+  subject { described_class.new enrollments }
+
+  def subject_with(*args)
+    described_class.new(*args)
+  end
+
+  describe "#start_date" do
+    let(:start_date) { 2.months.ago }
+
+    it "has a start date that is the oldest enrollment date" do
+      expect(subject.start_date).to eq(oldest_date)
+    end
+
+    it "has a specified start date if you provide it" do
+      subject = subject_with(enrollments, start_date: start_date)
+      expect(subject.start_date).to eq(start_date)
+    end
+  end
+
+  describe "#end_date" do
+    let(:end_date) { 2.months.from_now }
+
+    it "has an end date of today by default" do
+      expect(subject.end_date).to eq(Date.today)
+    end
+
+    it "has a specified end date if you provide it" do
+      subject = subject_with(enrollments, end_date: end_date)
+      expect(subject.end_date).to eq(end_date)
+    end
+  end
+
+  describe "#to_a" do
+    it "returns an array of the correct length" do
+      expect(subject.to_a).to have(num_enrollments).items
+    end
+
+    describe "result hash" do
+      let(:enrollment_data) { subject.to_a.first }
+
+      it "includes course info and progress" do
+        expect(enrollment_data.keys).to include(:course_name, :progress)
+      end
+
+      it "reflects the course name" do
+        expect(enrollment_data[:course_name])
+      end
+
+    end
+  end
+
+end

--- a/spec/models/progress_summary_spec.rb
+++ b/spec/models/progress_summary_spec.rb
@@ -1,3 +1,4 @@
+require 'pry'
 require 'spec_helper'
 
 describe ProgressSummary do
@@ -9,7 +10,7 @@ describe ProgressSummary do
 
   let(:enrollments)     { Enrollment.all }
   let(:num_enrollments) { enrollments.count }
-  let(:oldest_date)     { 1.year.ago }
+  let(:oldest_date)     { Date.today - 365 }
 
   subject { described_class.new enrollments }
 
@@ -18,20 +19,22 @@ describe ProgressSummary do
   end
 
   describe "#start_date" do
-    let(:start_date) { 2.months.ago }
+    let(:start_date) { Date.today - 30 }
 
     it "has a start date that is the oldest enrollment date" do
+      expect(subject.start_date).to be_kind_of(Date)
       expect(subject.start_date).to eq(oldest_date)
     end
 
     it "has a specified start date if you provide it" do
       subject = subject_with(enrollments, start_date: start_date)
+      expect(subject.start_date).to be_kind_of(Date)
       expect(subject.start_date).to eq(start_date)
     end
   end
 
   describe "#end_date" do
-    let(:end_date) { 2.months.from_now }
+    let(:end_date) { Date.today + 60 }
 
     it "has an end date of today by default" do
       expect(subject.end_date).to eq(Date.today)
@@ -44,21 +47,54 @@ describe ProgressSummary do
   end
 
   describe "#to_a" do
+    let(:enrollment_data) { subject.to_a.first }
+    let(:enrollment) { Enrollment.first }
+
     it "returns an array of the correct length" do
       expect(subject.to_a).to have(num_enrollments).items
     end
 
     describe "result hash" do
-      let(:enrollment_data) { subject.to_a.first }
-
       it "includes course info and progress" do
         expect(enrollment_data.keys).to include(:course_name, :progress)
       end
 
       it "reflects the course name" do
-        expect(enrollment_data[:course_name])
+        expect(enrollment_data[:course_name]).to eq(enrollment.course.name)
       end
 
+      it "has progress keys for each day in the range" do
+        subject = subject_with(enrollments, start_date: Date.today, end_date: Date.today+3)
+        data    = subject.to_a.first
+
+        expect(data[:progress]).to have(4).items
+        expect(data[:progress].keys).to eq([ Date.today, Date.today+1, Date.today+2, Date.today+3])
+      end
+    end
+
+    describe "dated results" do
+      before do
+        enrollments.each do |enrollment|
+          enrollment.update!(course: course)
+        end
+      end
+
+      let(:start_date) { enrollment.created_at.to_date }
+      let(:course) { create(:course, :with_skills) }
+      let(:total_skills) { course.skills.count }
+
+      it "returns the total number of skills when there have been no completions" do
+        expect(enrollment_data[:progress][start_date]).to eq(total_skills)
+        expect(enrollment_data[:progress][Date.today]).to eq(total_skills)
+      end
+
+      it "reduces the remaining count when a skill is completed" do
+        completion = create(:completion, created_at: start_date + 1
+                            skill: course.skills.last, user: enrollment.user)
+
+        expect(enrollment_data[:progress][start_date]).to eq(total_skills)
+        expect(enrollment_data[:progress][start_date + 1]).to eq(total_skills - 1)
+      end
     end
   end
 


### PR DESCRIPTION
Add a completion chart to user's profiles. Currently only shows one enrollment, for the current user (or an admin). Needs more love.