### PR TITLE
Added lsof line to UNIX exercises

### DIFF
--- a/app/views/categories/_linux.html.haml
+++ b/app/views/categories/_linux.html.haml
@@ -118,7 +118,8 @@
 
   = resource_block do |e|
     - e.text("Port (Computer Networking)", 'https://en.wikipedia.org/wiki/Port_(computer_networking)', "If you don't know about ports yet, Wikipedia to the rescue!")
-    - e.text("Netstat Command Examples", 'http://www.thegeekstuff.com/2010/03/netstat-command-examples/', "Netstat is the command we use to check ports. A lot.")
+    - e.text("Netstat Command Examples", 'http://www.thegeekstuff.com/2010/03/netstat-command-examples/', "Netstat is the command we use to check ports on Linux. A lot.")
+    - e.text("Lsof Man Pages", "https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man8/lsof.8.html", "For OSX check out lsof and bemoan the lack of feature standardization across NIXes")
 
   = exercise_block_for "ports" do |e|
     - e.question "Demonstrate the command to show the list of currently listening ports on your laptop."


### PR DESCRIPTION
netstat doesn't do quite the same thing for OSX, and it's easy to get thrown off.