### PR TITLE
Interactor cleanup.

### DIFF
--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -6,8 +6,6 @@ module CoursesHelper
 
   def completion_percent_for(course, user = current_user)
     summary = user.summary.for_course(course)
-
-    return 0 unless summary[:total] > 0
-    ((summary[:completed] / summary[:total].to_f) * 100).ceil
+    summary.fetch(:completed_percent, 0).ceil
   end
 end

--- a/app/interactors/complete_deadline.rb
+++ b/app/interactors/complete_deadline.rb
@@ -1,9 +1,15 @@
 class CompleteDeadline < ServiceObject
+  def setup
+    validate_key :category, :user
+    default :deadline, user_deadline
+  end
+
+  # return but don't fail if there's no deadline
   def run
-    return unless deadline.present?
+    return unless context.deadline
     return unless all_skills_completed?
 
-    deadline.update_attributes!(completed_on: Date.today)
+    context.deadline.update_attributes!(completed_on: Date.today)
   end
 
   private
@@ -14,10 +20,6 @@ class CompleteDeadline < ServiceObject
     completions  = Completion.where(user: context.user, skill: skill_ids)
 
     skill_ids.length == completions.count
-  end
-
-  def deadline
-    context.deadline || user_deadline
   end
 
   def user_deadline

--- a/app/interactors/complete_deadline.rb
+++ b/app/interactors/complete_deadline.rb
@@ -9,14 +9,18 @@ class CompleteDeadline < ServiceObject
   private
 
   def all_skills_completed?
-    all       = context.category.skills.pluck(:id)
-    complete  = Completion.where(user: context.user, skill: all).count
+    skills    = context.category.skills
+    skill_ids = skills.pluck(:id)
+    completions  = Completion.where(user: context.user, skill: skill_ids)
 
-    all.length == complete
+    skill_ids.length == completions.count
   end
 
   def deadline
-    context.deadline ||
-      Deadline.where(user: context.user, category: context.category).first
+    context.deadline || user_deadline
+  end
+
+  def user_deadline
+    Deadline.find_by(user: context.user, category: context.category)
   end
 end

--- a/app/interactors/complete_skill.rb
+++ b/app/interactors/complete_skill.rb
@@ -1,9 +1,9 @@
 class CompleteSkill < ServiceObject
+
   def setup
-    check_user
-    check_skill
-    check_recompletion
-    check_organization
+    validate_key :skill, :user
+    validate("cannot re-complete a skill") { |c| !Completion.for(c.user, c.skill) }
+    validate("provide a valid skill") { org_matches? }
   end
 
   def run
@@ -11,6 +11,10 @@ class CompleteSkill < ServiceObject
     complete_deadline
   rescue
     fail! "unable to complete skill"
+  end
+
+  def org_matches?
+    success? && skill_org.in?([nil, context.user.organization])
   end
 
   private
@@ -22,25 +26,6 @@ class CompleteSkill < ServiceObject
   def create_completion(user, skill)
     completion = Completion.new(user: user, skill: skill).tap(&:save!)
     context.completion = completion
-  end
-
-  def check_user
-    fail!("provide a valid user") unless context.user
-  end
-
-  def check_skill
-    fail!("provide a valid skill") unless context.skill
-  end
-
-  def check_recompletion
-    comp = Completion.for(context.user, context.skill)
-    fail!("cannot re-complete a skill") if comp
-  end
-
-  def check_organization
-    return if failure?
-
-    fail!("provide a valid skill") unless skill_org.in? [nil, context.user.organization]
   end
 
   def skill_org

--- a/app/interactors/enroll_user.rb
+++ b/app/interactors/enroll_user.rb
@@ -1,44 +1,40 @@
 class EnrollUser < ServiceObject
   def setup
-    fail! unless user_present?
-    fail! unless course_present?
-    fail! unless user_has_correct_org?(context.course, context.user)
+    validate_key :user, :course
+    validate("provide a valid course") { |c| user_has_correct_org?(c.course, c.user) }
+
+    default :user_mailer, UserMailer
+    default :admin_mailer, AdminMailer
   end
 
   def run
     add_user_enrollment || fail!("Couldn't add enrollment")
-    send_welcome_email || fail!("Couldn't send email")
+    send_welcome_emails || fail!("Couldn't send email")
   end
 
   private
 
-  def user_present?
-    context.user.present?
-  end
-
-  def course_present?
-    context.course.present?
-  end
-
   def user_has_correct_org?(course, user)
-    course.organization.blank? || course.organization == user.organization
+    course.organization.in? [nil, user.organization]
   end
 
   def add_user_enrollment
     Enrollment.create(course: context.course, user: context.user)
   end
 
-  def send_welcome_email
+  def send_welcome_emails
     mail_user && mail_admin
   end
 
   def mail_admin
-    mailer = context.admin_mailer || AdminMailer
-    mailer.confirm_enrollment(context.user, context.course).deliver_now
+    mailer = context.admin_mailer
+    mail = mailer.confirm_enrollment(context.user, context.course)
+    mail.deliver_now
   end
 
   def mail_user
-    mailer = context.user_mailer || UserMailer
-    mailer.confirm_enrollment(context.user, context.course).deliver_now
+    mailer = context.user_mailer
+    mail = mailer.confirm_enrollment(context.user, context.course)
+    mail.deliver_now
   end
 end

--- a/app/interactors/remind_registration_dropoffs.rb
+++ b/app/interactors/remind_registration_dropoffs.rb
@@ -1,4 +1,8 @@
 class RemindRegistrationDropoffs < ServiceObject
+  def setup
+    default :user_mailer, UserMailer
+  end
+
   def run
     context.users = lazy_users.each do |user|
       user.update_attributes!(enrollment_reminder_sent: true)
@@ -15,10 +19,7 @@ class RemindRegistrationDropoffs < ServiceObject
   end
 
   def remind(user)
-    user_mailer.reg_reminder(user).deliver_now
-  end
-
-  def user_mailer
-    context.user_mailer || UserMailer
+    mailer = context.user_mailer
+    mailer.reg_reminder(user).deliver_now
   end
 end

--- a/app/interactors/send_feedback.rb
+++ b/app/interactors/send_feedback.rb
@@ -1,8 +1,7 @@
 class SendFeedback < ServiceObject
   def setup
-    [:user, :page, :message].each do |var|
-      fail_unless_var_present(var)
-    end
+    validate_key :user, :page, :message
+    default :admin_mailer, AdminMailer
   end
 
   def run
@@ -14,14 +13,7 @@ class SendFeedback < ServiceObject
   private
 
   def feedback_message
-    admin_mailer.send_feedback(context.user, context.page, context.message)
-  end
-
-  def admin_mailer
-    context.admin_mailer || AdminMailer
-  end
-
-  def fail_unless_var_present(var)
-    fail!("provide a valid #{var}") unless context.send(var)
+    mailer = context.admin_mailer
+    mailer.send_feedback(context.user, context.page, context.message)
   end
 end

--- a/app/models/progress_summary.rb
+++ b/app/models/progress_summary.rb
@@ -20,7 +20,8 @@ class ProgressSummary
 
   def summarize_progress_for_enrollment(enrollment)
     { course_name: enrollment.course.name,
-      progress: progress_burndown(enrollment) }
+      progress: progress_burndown(enrollment)
+    }
   end
   private :summarize_progress_for_enrollment
 
@@ -36,12 +37,17 @@ class ProgressSummary
     skills_left = enrollment.course.skills.count
     completions = completions(enrollment)
 
-    start_date.upto(end_date).each_with_object({}) do |date, hash|
-      skills_left -= completions[date].length if completions[date]
-      hash[date] = skills_left
-    end
+    burn_downward(start_date.upto(end_date), skills_left, completions)
   end
   private :progress_burndown
+
+  def burn_downward(dates, remaining, completions)
+    dates.each_with_object({}) do |date, hash|
+      remaining -= completions.fetch(date, []).length
+      hash[date] = remaining
+    end
+  end
+  private :burn_downward
 
   def completions(enrollment)
     Completion.for_course(enrollment.user, enrollment.course)

--- a/app/models/service_object.rb
+++ b/app/models/service_object.rb
@@ -1,13 +1,17 @@
 class ServiceObject
   attr_reader :context
 
+  # setup
+
   def initialize(params = {})
     @context = OpenStruct.new
     params.each do |k, v|
       @context.send("#{k}=", v)
     end
-    setup if respond_to? :setup
+    setup if self.respond_to?(:setup)
   end
+
+  # error handling
 
   def errors
     @errors ||= []
@@ -29,6 +33,8 @@ class ServiceObject
     !failure?
   end
 
+  # execution
+
   def run
     fail NotImplementedError, "Please implement 'run' to perform the work."
   end
@@ -40,5 +46,21 @@ class ServiceObject
 
   def self.call(context = {})
     new(context).call
+  end
+
+  # validations
+
+  def validate(message, &block)
+    fail! message unless block.call(context)
+  end
+
+  def validate_key(*keys)
+    keys.each do |key|
+      self.validate("provide a valid #{key}") { |c| c.send(key).present? }
+    end
+  end
+
+  def default(key, value)
+    context.send("#{key}=", value) unless context.send(key).present?
   end
 end

--- a/app/models/user_summary.rb
+++ b/app/models/user_summary.rb
@@ -1,28 +1,45 @@
 class UserSummary
+  BASE_SUMMARY = { completed: 0, total: 0, verified: 0 }
+
   def initialize(user)
     @user = user
   end
 
   def for_user
-    @for_user ||= summary_data.map { |category| typecast_results_for(category) }
+    @for_user ||= summary_data.map do |category|
+      typecast_results_for(category)
+    end
   end
 
   def for_category(category)
-    summary = for_user.find { |data| category.handle == data[:handle] }
-    summary.presence || { total_skills: category.skills.count, total_completed: 0, total_verified: 0 }
+    summary = for_user.find do |data|
+      category.handle == data[:handle]
+    end
+
+    summary.presence || initialized_summary(category)
   end
 
   def for_course(course)
-    for_user.each_with_object(completed: 0, total: 0, verified: 0) do |c, hash|
+    for_user.each_with_object(BASE_SUMMARY) do |c, hash|
       next unless course.id == c[:course_id]
 
       hash[:completed]  += c[:total_completed]
       hash[:total]      += c[:total_skills]
       hash[:verified]   += c[:total_verified]
+
+      hash[:completed_percent] = completed_percent(hash[:completed], hash[:total])
     end
   end
 
   private
+
+  def completed_percent(completed, total)
+    ((completed / total) * 100).ceil
+  end
+
+  def initialized_summary(category)
+    { total_skills: category.skills.count, total_completed: 0, total_verified: 0 }
+  end
 
   def summary_data
     connection.execute(summary_query)

--- a/app/models/user_summary.rb
+++ b/app/models/user_summary.rb
@@ -27,14 +27,14 @@ class UserSummary
       hash[:total]      += c[:total_skills]
       hash[:verified]   += c[:total_verified]
 
-      hash[:completed_percent] = completed_percent(hash[:completed], hash[:total])
+      hash[:completed_percent] = completed_percent(hash)
     end
   end
 
   private
 
-  def completed_percent(completed, total)
-    ((completed / total) * 100).ceil
+  def completed_percent(hash)
+    ((hash[:completed] / hash[:total]) * 100).ceil
   end
 
   def initialized_summary(category)
@@ -55,14 +55,12 @@ class UserSummary
     group by e.course_id, c.id, c.handle, sort_order order by sort_order"
   end
 
+  INTEGER_FIELDS = [:id, :course_id, :total_skills, :total_completed, :total_verified]
+
   def typecast_results_for(category)
-    { id:               category['id'].to_i,
-      name:             category['name'],
-      handle:           category['handle'],
-      course_id:        category['course_id'].to_i,
-      total_skills:     category['total_skills'].to_i,
-      total_completed:  category['total_completed'].to_i,
-      total_verified:   category['total_verified'].to_i }
+    category.symbolize_keys!.tap do |hash|
+      INTEGER_FIELDS.each { |field| hash[field] = hash[field].to_i }
+    end
   end
 
   def connection

--- a/spec/interactors/complete_skill_spec.rb
+++ b/spec/interactors/complete_skill_spec.rb
@@ -10,6 +10,11 @@ describe CompleteSkill do
     subject.new(skill: the_skill, user: the_user).call
   end
 
+  it "requires a valid skill" do
+    response = interactor(the_skill: nil)
+    expect(response.errors).to include("provide a valid skill")
+  end
+
   it "allows the user to complete a skill" do
     expect(interactor).to be_success
     expect(user.skills(skill.category)).to include(skill)

--- a/spec/interactors/enroll_user_spec.rb
+++ b/spec/interactors/enroll_user_spec.rb
@@ -5,8 +5,8 @@ describe EnrollUser do
   let(:course)  { create(:course) }
   let(:user)    { create(:user) }
 
-  let(:amailer) { spy("AdminMailer", confirm_enrollment: mail) }
-  let(:umailer) { spy("UserMailer", confirm_enrollment: mail) }
+  let(:amailer) { spy("AdminMailer", present?: true, confirm_enrollment: mail) }
+  let(:umailer) { spy("UserMailer", present?: true, confirm_enrollment: mail) }
 
   def interactor(opts = {})
     @interactor ||= subject.new({ course: course, user: user }.merge(opts))

--- a/spec/interactors/remind_activity_dropoffs_spec.rb
+++ b/spec/interactors/remind_activity_dropoffs_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe RemindActivityDropoffs do
   subject(:interactor) { described_class.new(user_mailer: umailer) }
   let(:course)  { create(:course, :with_skills) }
-  let(:umailer) { spy("UserMailer", activity_reminder: spy) }
+  let(:umailer) { spy("UserMailer", present?: true, activity_reminder: spy) }
   let!(:enroll) { create(:enrollment, course: course, created_at: 1.year.ago) }
 
   it "sends email to users who've become stuck" do

--- a/spec/interactors/remind_deadlines_spec.rb
+++ b/spec/interactors/remind_deadlines_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe RemindDeadlines do
   subject(:interactor) { described_class.new(user_mailer: umailer, now: now) }
   let(:now) { Time.now }
-  let(:umailer) { spy("UserMailer") }
+  let(:umailer) { spy("UserMailer", present?: true) }
   let(:deadline) { Deadline.new(user: User.new) }
 
   it "sends email to users who've become stuck" do
     allow(deadline).to receive(:update_attributes!) { true }
-    allow(interactor).to receive(:targets) { [deadline] }
+    interactor = described_class.new(deadlines: [deadline], user_mailer: umailer, now: now)
 
     interactor.call
 
@@ -24,8 +24,8 @@ describe RemindDeadlines do
   end
 
   it "updates the deadline params" do
-    allow(interactor).to receive(:targets) { [deadline] }
     allow(deadline).to receive(:update_attributes!) { true }
+    interactor = described_class.new(deadlines: [deadline], user_mailer: umailer, now: now)
 
     interactor.call
 


### PR DESCRIPTION
Mostly:
1. Find the biggest floggy methods and break them into multiple methods.
2. Refactor messy methods to be One Idea Per Line

But *still* this makes almost no dent in the total
flog of the application. We're mostly shuffling complexity around.

However, also added default() and validate() calls to the ServiceObject
class, because a huge amount of each class has been dealing with the
setup of those objects.

I'd still like to do something to eliminate the scourge of `context.foo`
calls all over the interactions, but that will have to wait.